### PR TITLE
Fixed issue-16

### DIFF
--- a/include/delaunator.hpp
+++ b/include/delaunator.hpp
@@ -508,7 +508,7 @@ std::size_t Delaunator::legalize(std::size_t a) {
                         hull_tri[e] = a;
                         break;
                     }
-                    e = hull_next[e];
+                    e = hull_prev[e];
                 } while (e != hull_start);
             }
             link(a, hbl);


### PR DESCRIPTION
Fixes #16 to prevent infinite recursion when a triangle was previously deleted from hull_next.

Port of fix in original JavaScript https://github.com/mapbox/delaunator/issues/44